### PR TITLE
Adding "-S" to shebang

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --harmony
+#!/usr/bin/env -S node --harmony
 'use strict'
 
 /*


### PR DESCRIPTION
On Linux, /usr/bin/env cannot handle parameteres for the command to be run 'node --harmony' by default. Adding '/usr/bin/env -S' works around that. (Not sure if it affects other platforms, though.)